### PR TITLE
Prefix routing to prevent errors

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ Sorting Plugin
 
 1. Run `$ composer require mangoweb-sylius/sylius-sorting-plugin`.
 2. Register `\MangoSylius\SortingPlugin\MangoSyliusSortingPlugin` in your Kernel.
-3. Import `@MangoSyliusSortingPlugin/Resources/config/routing.yml` in the routing.yml.
+3. Import `@MangoSyliusSortingPlugin/Resources/config/routing.yml` in the routing.yml with a prefix of /admin.
 
 ## Usage
 


### PR DESCRIPTION
The routing import should have an /admin prefix, since the admin section is a seperate firewall and otherwise app.user isn't populated and will throw errors